### PR TITLE
Check if iobroker object name contains propertyname

### DIFF
--- a/AppBokerASP/Devices/Zigbee/ZigbeeDevice.cs
+++ b/AppBokerASP/Devices/Zigbee/ZigbeeDevice.cs
@@ -32,7 +32,7 @@ namespace AppBokerASP.Devices.Zigbee
 
         public void SetPropFromIoBroker(IoBrokerObject ioBrokerObject, bool setLastReceived)
         {
-            var prop = propertyInfos.FirstOrDefault(x => x.Name.ToLower() == ioBrokerObject.ValueName);
+            var prop = propertyInfos.FirstOrDefault(x => ioBrokerObject.ValueName.Contains(x.Name.ToLower()));
             if (prop == default || ioBrokerObject.ValueParameter.Value == null)
                 return;
             if ((prop.PropertyType == typeof(float) || prop.PropertyType == typeof(double)) && ioBrokerObject.ValueParameter.Value.ToObject<string>()!.Contains(","))

--- a/AppBokerASP/Program.cs
+++ b/AppBokerASP/Program.cs
@@ -71,7 +71,7 @@ namespace AppBokerASP
 
 
 
-            Dostuff();
+            //Dostuff();
             if (painlessMeshSettings.Enabled)
                 MeshManager.Start();
 


### PR DESCRIPTION
Because my installation has the values like `room_temperature` and not only `temperature`